### PR TITLE
add russian langage mode keys for convenience

### DIFF
--- a/pkg/tui/list-mrs.go
+++ b/pkg/tui/list-mrs.go
@@ -95,7 +95,7 @@ func (l *ListPR) OnKey(key string, _ int, pr git.PullRequest) (reload bool, err 
 			return false, fmt.Errorf("copy URL to clipboard: %w", err)
 		}
 		return false, nil
-	case "a":
+	case "a", "ф":
 		if err = l.Service.Approve(l.ctx, pr.Project.ID, pr.Number); err != nil {
 			return false, fmt.Errorf("approve PR: %w", err)
 		}

--- a/pkg/tui/teax/datatable.go
+++ b/pkg/tui/teax/datatable.go
@@ -134,9 +134,9 @@ func (t *RefreshingDataTable[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		switch msg.String() {
-		case "ctrl+c", "c+ctrl", "q":
+		case "ctrl+c", "c+ctrl", "q", "й":
 			return t, tea.Quit
-		case "r":
+		case "r", "к":
 			return t, t.reloadCmd()
 		default:
 			return t, t.keyCmd(msg.String())


### PR DESCRIPTION
Неудобно следить за раскладкой. Программа визуально никак не реагирует на неизвестные кнопки, сложно понять что жмешь не в той раскладке или просто действие тормозит.
Добавил русские варианты кнопок, которые в QWERTY раскладке на тех же местах, что  "q", "r", "a".